### PR TITLE
Updated parity version  to  2.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Dappnode package responsible for providing the Ethereum blockchain service. 
 
-Actually based on version v1.10.6 of [Parity](https://github.com/paritytech/parity/releases/tag/v2.2.2)
+Actually based on version 2.2.2 of [Parity](https://github.com/paritytech/parity/releases/tag/v2.2.2)
 
 It is an AragonApp whose repo is deployed at this address: [0x30a933d920bc4a71a446a0f15f0e80eaf2383fc9 ](https://etherscan.io/address/0x30a933d920bc4a71a446a0f15f0e80eaf2383fc9 ) and whose ENS address is: [ethchain.dnp.dappnode.eth](https://etherscan.io/enslookup?q=ethchain.dnp.dappnode.eth])
 


### PR DESCRIPTION
the text description was saying that is based on parity 1 .10.6 and the link is pointing to 2.2.2 "No nick"